### PR TITLE
 window.fetch set undefined to avoid use this api

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -6,6 +6,9 @@
     <meta name='viewport' content='initial-scale=1,maximum-scale=1,user-scalable=no'/>
     <link href='mapbox-gl.css' rel='stylesheet'/>
     <script type="text/javascript" src="cordova.js"></script>
+    <!-- Hack needed to avoid the window.fetch use since 0.51.0 mapboxgljs version
+        https://github.com/mapbox/mapbox-gl-js/blob/v0.51.0/src/util/ajax.js#L156 -->
+    <script type="text/javascript">window.fetch = undefined</script>
     <!--script src='http://172.27.203.11:8080/www/mapbox-gl-cordova-offline-dev.js'></script-->
     <script src='mapbox-gl-cordova-offline.js'></script>
     <style>


### PR DESCRIPTION
Added hack to set undefined window.fetch on browser and force mapbox to use XHR